### PR TITLE
Top progress bar on navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "canvas-confetti": "^1.9.3",
     "next": "15.5.9",
     "next-themes": "^0.4.6",
+    "nextjs-toploader": "^3.9.17",
     "pg": "^8.22.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Rubik } from "next/font/google";
+import NextTopLoader from "nextjs-toploader";
 import { Provider } from "@/components/ui/provider";
 import { Header } from "@/components/layout/header";
 import { Toaster } from "@/components/ui/toaster";
@@ -22,6 +23,13 @@ export default function RootLayout({
   return (
     <html className={`${rubik.variable}`} lang="en" suppressHydrationWarning>
       <body>
+        {/* Thin progress bar shown during route/page navigations. */}
+        <NextTopLoader
+          color="#3b82f6"
+          height={3}
+          showSpinner={false}
+          shadow="0 0 10px #3b82f6, 0 0 5px #3b82f6"
+        />
         <Provider>
           <Toaster />
           <Header />

--- a/yarn.lock
+++ b/yarn.lock
@@ -4941,6 +4941,14 @@ next@15.5.9:
     "@next/swc-win32-x64-msvc" "15.5.7"
     sharp "^0.34.3"
 
+nextjs-toploader@^3.9.17:
+  version "3.9.17"
+  resolved "https://registry.yarnpkg.com/nextjs-toploader/-/nextjs-toploader-3.9.17.tgz#3bb54918738c31ac1efbaf6a01518dbee27ebf99"
+  integrity sha512-9OF0KSSLtoSAuNg2LZ3aTl4hR9mBDj5L9s9DZiFCbMlXehyICGjkIz5dVGzuATU2bheJZoBdFgq9w07AKSuQQw==
+  dependencies:
+    nprogress "^0.2.0"
+    prop-types "^15.8.1"
+
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -4962,6 +4970,11 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
+
+nprogress@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/nprogress/-/nprogress-0.2.0.tgz#cb8f34c53213d895723fcbab907e9422adbcafb1"
+  integrity sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==
 
 nwsapi@^2.2.2:
   version "2.2.21"


### PR DESCRIPTION
## What
A thin **top loading bar** that animates during client navigations (Link clicks, `router.push`, browser back/forward). Useful because the tournament pages render server-side, so navigations have a real loading window.

## How
Uses [`nextjs-toploader`](https://github.com/TheSGJ/nextjs-toploader) — App Router-native. A hand-rolled version has to intercept link clicks, patch `history.pushState`/`replaceState`, handle `popstate`, and get the completion timing right (App Router has no global navigation event); the library handles all of that. Mounted once in the root layout:

```tsx
<NextTopLoader color="#3b82f6" height={3} showSpinner={false}
  shadow="0 0 10px #3b82f6, 0 0 5px #3b82f6" />
```

Blue to match the app's primary color, 3px, no corner spinner (bar only).

## Verification
- `tsc` clean · eslint clean · **141/141 tests pass** · `next build` succeeds.
- Independent of the match-flow work (PR #11); branched off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)