### PR TITLE
feat: standings NR column + Tied relabel, and playoff format selector redesign

### DIFF
--- a/src/components/tournaments/playoff-format-selector.tsx
+++ b/src/components/tournaments/playoff-format-selector.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Text, VStack, HStack, Badge, Card } from "@chakra-ui/react";
+import { LuCheck } from "react-icons/lu";
 import type { PlayoffFormat } from "@/contexts/tournament-context/types";
 import WorldCupTrophyIcon from "../icons/world-cup-trophy-icon";
 import LeagueTrophyIcon from "../icons/league-trophy-icon";
@@ -19,116 +20,177 @@ export function PlayoffFormatSelector({
   const formatDetails = {
     "world-cup": {
       name: "World Cup Style",
-      description: "Simple knockout format",
-      icon: <WorldCupTrophyIcon />,
+      tag: "ICC · T20 WC",
+      description: "Simple knockout — no second chances",
+      icon: <WorldCupTrophyIcon width={22} height={22} />,
       color: "blue",
       stages: [
         "Semi-Final 1: 1st vs 4th",
         "Semi-Final 2: 2nd vs 3rd",
-        "Final: Winner SF1 vs Winner SF2 (Winner → Champion)",
+        "Final: Winner SF1 vs Winner SF2 (→ Champion)",
       ],
     },
     league: {
-      name: "League Style (IPL/BBL/PSL)",
-      description: "Top teams get second chances",
-      icon: <LeagueTrophyIcon />,
-      color: "blue",
+      name: "League Style",
+      tag: "IPL · BBL · PSL",
+      description: "Top two get a second chance",
+      icon: <LeagueTrophyIcon width={22} height={22} />,
+      color: "purple",
       stages: [
         "Qualifier 1: 1st vs 2nd (Winner → Final)",
-        "Eliminator: 3rd vs 4th (Loser eliminated)",
+        "Eliminator: 3rd vs 4th (Loser out)",
         "Qualifier 2: Loser Q1 vs Winner Eliminator",
-        "Final: Winner Q1 vs Winner Q2 (Winner → Champion)",
+        "Final: Winner Q1 vs Winner Q2 (→ Champion)",
       ],
     },
   } as const;
 
   return (
-    <VStack align="stretch" gap={4}>
-      <VStack gap={3} align="stretch">
-        {(Object.keys(formatDetails) as PlayoffFormat[]).map((format) => {
-          const details = formatDetails[format];
-          const isSelected = value === format;
+    <VStack align="stretch" gap={3} role="radiogroup" aria-label="Playoff format">
+      {(Object.keys(formatDetails) as PlayoffFormat[]).map((format) => {
+        const details = formatDetails[format];
+        const isSelected = value === format;
 
-          return (
-            <Card.Root
-              key={format}
-              w="full"
-              borderWidth={2}
-              borderColor={isSelected ? "card.selectedBorder" : "gray.700"}
-              bg={isSelected ? "card.selected" : "card.bg"}
-              cursor={disabled ? "not-allowed" : "pointer"}
-              opacity={disabled ? 0.6 : 1}
-              onClick={() => !disabled && onChange(format)}
-              _hover={
-                !disabled
-                  ? {
-                      transform: "translateY(-1px)",
-                      shadow: "sm",
-                    }
-                  : {}
+        // Explicit light/dark color pairs from the raw palette scales. We avoid
+        // this theme's `colorPalette.*` semantic tokens for tinted backgrounds
+        // because their low shades don't invert reliably in dark mode.
+        const c = details.color;
+        const tintBg = { base: `${c}.50`, _dark: `${c}.950` };
+        const solidBorder = `${c}.500`;
+        const hoverBorder = { base: `${c}.300`, _dark: `${c}.600` };
+        const chipBg = { base: `${c}.100`, _dark: `${c}.900` };
+        const iconColor = { base: `${c}.600`, _dark: `${c}.300` };
+        const numColor = { base: `${c}.700`, _dark: `${c}.300` };
+
+        return (
+          <Card.Root
+            key={format}
+            role="radio"
+            aria-checked={isSelected}
+            aria-disabled={disabled || undefined}
+            tabIndex={disabled ? -1 : 0}
+            w="full"
+            borderWidth={2}
+            borderRadius="xl"
+            borderColor={isSelected ? solidBorder : "border.default"}
+            bg={isSelected ? tintBg : "card.bg"}
+            cursor={disabled ? "not-allowed" : "pointer"}
+            opacity={disabled ? 0.6 : 1}
+            transition="border-color 0.15s ease, background 0.15s ease"
+            onClick={() => !disabled && onChange(format)}
+            onKeyDown={(e) => {
+              if (disabled) return;
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onChange(format);
               }
-              colorPalette={details.color}
-            >
-              <Card.Body p={4}>
-                <VStack align="stretch" gap={3}>
-                  {/* Header */}
-                  <HStack justify="space-between" align="center">
-                    <HStack gap={2}>
-                      <Text
-                        fontSize="xl"
-                        color={isSelected ? "fg.default" : "gray.400"}
-                      >
-                        {details.icon}
-                      </Text>
-                      <VStack align="start" gap={0}>
+            }}
+            _hover={
+              !disabled && !isSelected
+                ? { borderColor: hoverBorder, bg: "bg.subtle" }
+                : {}
+            }
+            _focusVisible={{
+              outline: "2px solid",
+              outlineColor: solidBorder,
+              outlineOffset: "2px",
+            }}
+          >
+            <Card.Body p={{ base: 4, md: 5 }}>
+              <VStack align="stretch" gap={3.5}>
+                {/* Header */}
+                <HStack justify="space-between" align="flex-start" gap={3}>
+                  <HStack gap={3} align="center">
+                    {/* Icon tile */}
+                    <Box
+                      flexShrink={0}
+                      p={2.5}
+                      borderRadius="lg"
+                      bg={chipBg}
+                      color={iconColor}
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      {details.icon}
+                    </Box>
+                    <VStack align="start" gap={0.5}>
+                      <HStack gap={2} align="center" flexWrap="wrap">
                         <Text
                           fontWeight="bold"
-                          fontSize="sm"
-                          color={isSelected ? "fg.default" : "gray.400"}
+                          fontSize="md"
+                          color="fg.default"
+                          lineHeight="1.2"
                         >
                           {details.name}
                         </Text>
-                        <Text
-                          fontSize="xs"
-                          color={isSelected ? "fg.default" : "gray.400"}
+                        <Badge
+                          colorPalette={details.color}
+                          variant="subtle"
+                          fontSize="2xs"
+                          px={1.5}
+                          borderRadius="sm"
                         >
-                          {details.description}
-                        </Text>
-                      </VStack>
-                    </HStack>
-                    {isSelected && (
-                      <Badge colorPalette={details.color} variant="solid">
-                        Selected
-                      </Badge>
-                    )}
+                          {details.tag}
+                        </Badge>
+                      </HStack>
+                      <Text fontSize="sm" color="fg.muted" lineHeight="1.3">
+                        {details.description}
+                      </Text>
+                    </VStack>
                   </HStack>
 
-                  {/* Stages */}
-                  <VStack align="start" gap={1}>
-                    {details.stages.map((stage, index) => (
-                      <Text
-                        key={index}
-                        fontSize="xs"
-                        color={isSelected ? "fg.default" : "gray.400"}
-                      >
-                        {index + 1}. {stage}
-                      </Text>
-                    ))}
-                  </VStack>
-                </VStack>
-              </Card.Body>
-            </Card.Root>
-          );
-        })}
-      </VStack>
+                  {/* Radio indicator */}
+                  <Box
+                    flexShrink={0}
+                    boxSize={5}
+                    borderRadius="full"
+                    borderWidth={2}
+                    borderColor={isSelected ? solidBorder : "border.emphasized"}
+                    bg={isSelected ? solidBorder : "transparent"}
+                    color="white"
+                    display="flex"
+                    alignItems="center"
+                    justifyContent="center"
+                    transition="all 0.15s ease"
+                  >
+                    {isSelected && <LuCheck size={12} strokeWidth={3} />}
+                  </Box>
+                </HStack>
 
-      {/* Current Selection Info */}
-      <Box p={3} bg="blue.50" borderRadius="md">
-        <Text fontSize="sm" color="blue.700">
-          <strong>Selected:</strong> {formatDetails[value].name} -{" "}
-          {formatDetails[value].description}
-        </Text>
-      </Box>
+                {/* Divider */}
+                <Box borderTopWidth={1} borderColor="border.subtle" />
+
+                {/* Stages */}
+                <VStack align="stretch" gap={2}>
+                  {details.stages.map((stage, index) => (
+                    <HStack key={index} align="flex-start" gap={2.5}>
+                      <Box
+                        flexShrink={0}
+                        mt="1px"
+                        boxSize={5}
+                        borderRadius="full"
+                        bg={chipBg}
+                        color={numColor}
+                        fontSize="2xs"
+                        fontWeight="bold"
+                        display="flex"
+                        alignItems="center"
+                        justifyContent="center"
+                      >
+                        {index + 1}
+                      </Box>
+                      <Text fontSize="sm" color="fg.muted" lineHeight="1.4">
+                        {stage}
+                      </Text>
+                    </HStack>
+                  ))}
+                </VStack>
+              </VStack>
+            </Card.Body>
+          </Card.Root>
+        );
+      })}
     </VStack>
   );
 }

--- a/src/components/tournaments/tournament-standings.tsx
+++ b/src/components/tournaments/tournament-standings.tsx
@@ -70,7 +70,7 @@ export function TournamentStandings({
                 fontWeight="bold"
                 color="fg.default"
               >
-                D
+                T
               </Table.ColumnHeader>
               <Table.ColumnHeader
                 textAlign="center"
@@ -126,7 +126,7 @@ export function TournamentStandings({
           <Text>P - Played</Text>
           <Text>W - Won</Text>
           <Text>L - Lost</Text>
-          <Text>D - Draw</Text>
+          <Text>T - Tied</Text>
           <Text>NR - No Result</Text>
           <Text>Pts - Points</Text>
           <Text>NRR - Net Run Rate</Text>
@@ -214,7 +214,7 @@ function StandingsRow({ team, position, totalTeams }: StandingsRowProps) {
         </Badge>
       </Table.Cell>
 
-      {/* Draw */}
+      {/* Tied (a limited-overs "tie" — internal field is `draws`) */}
       <Table.Cell textAlign="center">
         <Badge
           colorPalette="gray"

--- a/src/components/tournaments/tournament-standings.tsx
+++ b/src/components/tournaments/tournament-standings.tsx
@@ -78,6 +78,14 @@ export function TournamentStandings({
                 fontWeight="bold"
                 color="fg.default"
               >
+                NR
+              </Table.ColumnHeader>
+              <Table.ColumnHeader
+                textAlign="center"
+                fontSize={{ base: "xs", md: "sm" }}
+                fontWeight="bold"
+                color="fg.default"
+              >
                 Pts
               </Table.ColumnHeader>
               <Table.ColumnHeader
@@ -119,6 +127,7 @@ export function TournamentStandings({
           <Text>W - Won</Text>
           <Text>L - Lost</Text>
           <Text>D - Draw</Text>
+          <Text>NR - No Result</Text>
           <Text>Pts - Points</Text>
           <Text>NRR - Net Run Rate</Text>
         </HStack>
@@ -214,6 +223,18 @@ function StandingsRow({ team, position, totalTeams }: StandingsRowProps) {
           px={{ base: 1, md: 2 }}
         >
           {team.draws}
+        </Badge>
+      </Table.Cell>
+
+      {/* No Result */}
+      <Table.Cell textAlign="center">
+        <Badge
+          colorPalette="orange"
+          variant="subtle"
+          fontSize={{ base: "xs", md: "sm" }}
+          px={{ base: 1, md: 2 }}
+        >
+          {team.noResults}
         </Badge>
       </Table.Cell>
 


### PR DESCRIPTION
Three related UI improvements to the round-robin tournament flow.

---

## 1. Standings: add a No Result (NR) column

The table awards points for **No Result** matches (both teams get 1 point) but had **no column** to show them, so points didn't reconcile with the visible W/L/D counts (e.g. a team with 0W/0L/0D showing 2 pts read as broken).

Added a dedicated **NR** column sourced from the already-tracked `noResults` stat — display-only, no engine/schema changes.

| Team | P | W | L | T | NR | Pts |
|------|---|---|---|---|----|-----|
| Salman | 2 | 1 | 0 | 0 | 1 | 3 |
| Asad | 2 | 0 | 0 | 0 | 2 | 2 |
| Ali | 2 | 0 | 1 | 0 | 1 | 1 |

## 2. Standings: relabel "D — Draw" as "T — Tied"

This is a limited-overs app, where cricket has no *draws* — only **ties** (scores level) and **no-results**. The `isDraw` flag has always represented a tie (match status text already reads "Match Tied"). Display-only relabel; internal `draws` field and DB columns unchanged.

**Cricket-rules note (unchanged, confirmed correct):** NR is excluded from NRR (only matches with a result count); ties are included. Points: Win 2, Tie 1 each, NR 1 each, Loss 0 — the standard ICC/IPL scheme.

## 3. Playoff format selector redesign

The old cards greyed the unselected option to `gray.400`, so the League option read as **disabled/unavailable** rather than choosable, and selection had no clear affordance.

Redesigned as an accessible radio group:
- Both options stay fully legible; only the selection state differs (colored border + subtle tint + filled check-radio).
- Distinct accent per format (World Cup = blue, League = purple), app-icon tile, tag badge, numbered stage badges + divider.
- **Accessibility:** `role="radiogroup"`/`"radio"`, `aria-checked`, Tab focus, Enter/Space activation, visible focus ring.
- **Theme-aware** via explicit light/dark color pairs. (Fixed a dark-mode bug where the selected card rendered white-on-light because this theme's custom `colorPalette.*` low-shade tokens don't invert reliably.)
- Removed the redundant bottom "Selected: ..." echo box.

Verified live in **light + dark**, across selected/unselected states, via a headless browser pass.

## Testing

- `yarn tsc --noEmit` — clean
- `yarn test` — 148/148 passing
- `yarn lint` — no new issues (2 pre-existing, in untouched files)
- Playoff selector: manually verified in a headless browser in light + dark mode, both selection states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)