### PR TITLE
feat(sharing): shareable pre-match fixture card

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.101.2",
     "better-auth": "^1.6.23",
     "canvas-confetti": "^1.9.3",
+    "html-to-image": "^1.11.13",
     "next": "15.5.9",
     "next-themes": "^0.4.6",
     "nextjs-toploader": "^3.9.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       canvas-confetti:
         specifier: ^1.9.3
         version: 1.9.4
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       next:
         specifier: 15.5.9
         version: 15.5.9(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2243,6 +2246,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
@@ -5931,8 +5937,8 @@ snapshots:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.9.3)
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5)
       eslint-plugin-react: 7.37.5(eslint@9.39.5)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.5)
@@ -5951,7 +5957,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5962,22 +5968,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5)(typescript@5.9.3)
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5988,7 +5994,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5)(typescript@5.9.3))(eslint@9.39.5))(eslint@9.39.5))(eslint@9.39.5)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -6330,6 +6336,8 @@ snapshots:
       whatwg-encoding: 2.0.0
 
   html-escaper@2.0.2: {}
+
+  html-to-image@1.11.13: {}
 
   http-proxy-agent@5.0.0:
     dependencies:

--- a/src/app/tournament/round-robin/[id]/layout.tsx
+++ b/src/app/tournament/round-robin/[id]/layout.tsx
@@ -28,7 +28,12 @@ export default async function RoundRobinTournamentLayout({
   return (
     <LiveTournamentProvider
       key={record.status}
-      init={{ id: record.id, status: record.status, state: record.state }}
+      init={{
+        id: record.id,
+        name: record.name,
+        status: record.status,
+        state: record.state,
+      }}
     >
       <TournamentHeader name={record.name} />
       <Box

--- a/src/components/tournaments/fixture-card.tsx
+++ b/src/components/tournaments/fixture-card.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { forwardRef } from "react";
+import type {
+  TournamentState,
+  PlayoffSlot,
+} from "@/contexts/tournament-context/types";
+
+/**
+ * The shareable fixture-draft card. Rendered at a fixed 1080px design width and
+ * captured to a PNG (see ShareFixtureDialog) for posting to WhatsApp etc.
+ *
+ * Intentionally styled with explicit hex colors and inline styles rather than
+ * Chakra theme tokens: the exported image must look identical for every viewer
+ * and must NOT follow the app's light/dark mode. This is the one place a fixed
+ * pixel width is correct — the output is an image, not a responsive screen.
+ */
+
+// Fixed design palette (theme-independent) — the app's blue scale (theme.ts).
+const INK = "#0c142e"; // blue.950 — deep ground
+const INK_2 = "#1a365d"; // blue.900
+const CARD = "rgba(255,255,255,0.05)";
+const CARD_BORDER = "rgba(255,255,255,0.12)";
+const ACCENT = "#63b3ed"; // blue.300 — bright accent on dark
+const ACCENT_SOFT = "99,179,237"; // blue.300 as rgb, for translucent fills
+const TEXT = "#eaf2fb";
+const MUTED = "#9db6d4";
+const FONT =
+  '"Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
+
+export const FIXTURE_CARD_WIDTH = 1080;
+
+export interface FixtureCardProps {
+  tournamentName: string;
+  state: TournamentState;
+}
+
+interface WindowParts {
+  date: string;
+  time: string;
+  duration: string | null;
+}
+
+/** Break the planned window into minimal, pre-formatted pieces (or null). */
+function windowParts(startISO?: string, endISO?: string): WindowParts | null {
+  if (!startISO) return null;
+  const start = new Date(startISO);
+  if (Number.isNaN(start.getTime())) return null;
+
+  const date = start
+    .toLocaleDateString(undefined, {
+      weekday: "short",
+      day: "numeric",
+      month: "short",
+    })
+    .toUpperCase();
+  const t = (d: Date) =>
+    d.toLocaleTimeString(undefined, { hour: "numeric", minute: "2-digit" });
+
+  if (!endISO) return { date, time: t(start), duration: null };
+  const end = new Date(endISO);
+  if (Number.isNaN(end.getTime())) return { date, time: t(start), duration: null };
+
+  const mins = Math.round((end.getTime() - start.getTime()) / 60000);
+  let duration: string | null = null;
+  if (mins > 0) {
+    const h = Math.floor(mins / 60);
+    const m = mins % 60;
+    duration = h && m ? `${h}h ${m}m` : h ? `${h}h` : `${m}m`;
+  }
+  return { date, time: `${t(start)} – ${t(end)}`, duration };
+}
+
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`;
+}
+
+/** Human description of a playoff slot for the pre-tournament draft. Avoids the
+ *  jargon "seed" — spells out the points-table position instead. */
+function describeSlot(slot: PlayoffSlot, labelById: Map<string, string>): string {
+  if (slot.kind === "seed") return `${ordinal(slot.seed)} on points table`;
+  const l = labelById.get(slot.matchId) ?? "TBD";
+  return slot.kind === "winnerOf" ? `Winner · ${l}` : `Loser · ${l}`;
+}
+
+function playoffSummary(state: TournamentState): string | null {
+  const { playoffConfig, playoffFormat } = state;
+  if (!playoffConfig || playoffFormat === "none" || playoffConfig.qualifiers === 0) {
+    return null;
+  }
+  const pretty: Record<string, string> = {
+    "final-only": "Final",
+    "world-cup": "Knockout",
+    league: "League playoffs",
+    custom: "Custom bracket",
+  };
+  return `Top ${playoffConfig.qualifiers} → ${pretty[playoffFormat] ?? "Playoffs"}`;
+}
+
+export const FixtureCard = forwardRef<HTMLDivElement, FixtureCardProps>(
+  function FixtureCard({ tournamentName, state }, ref) {
+    const win = windowParts(state.scheduledStart, state.scheduledEnd);
+
+    const groupMatches = state.matches
+      .filter((m) => !m.isPlayoff)
+      .sort((a, b) => a.round - b.round);
+
+    const playoffSpecs = state.playoffConfig?.matches ?? [];
+    const labelById = new Map(playoffSpecs.map((s) => [s.id, s.label]));
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          width: FIXTURE_CARD_WIDTH,
+          boxSizing: "border-box",
+          fontFamily: FONT,
+          color: TEXT,
+          background: `radial-gradient(120% 80% at 50% -10%, ${INK_2} 0%, ${INK} 60%)`,
+          padding: "72px 64px 60px",
+        }}
+      >
+        {/* Eyebrow */}
+        <div
+          style={{
+            fontSize: 24,
+            fontWeight: 700,
+            letterSpacing: 4,
+            color: ACCENT,
+          }}
+        >
+          🏏 FIXTURE DRAFT
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: 78,
+            fontWeight: 800,
+            lineHeight: 1.04,
+            marginTop: 16,
+            letterSpacing: -1,
+          }}
+        >
+          {tournamentName}
+        </div>
+
+        {/* Minimal schedule line */}
+        {win && (
+          <div style={{ marginTop: 24, display: "flex", alignItems: "baseline", flexWrap: "wrap", gap: 18 }}>
+            <span style={{ fontSize: 30, fontWeight: 700, color: ACCENT, letterSpacing: 2 }}>
+              {win.date}
+            </span>
+            <span style={{ fontSize: 30, fontWeight: 500, color: TEXT }}>
+              {win.time}
+            </span>
+            {win.duration && (
+              <span style={{ fontSize: 26, fontWeight: 500, color: MUTED }}>
+                · {win.duration}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Group stage */}
+        {groupMatches.length > 0 && (
+          <>
+            <SectionLabel>
+              GROUP STAGE · {groupMatches.length} MATCHES
+            </SectionLabel>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 22 }}>
+              {groupMatches.map((m, i) => (
+                <MatchCardRow
+                  key={m.id}
+                  tag={`MATCH ${String(i + 1).padStart(2, "0")}`}
+                  left={m.team1}
+                  right={m.team2}
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Playoffs */}
+        {playoffSpecs.length > 0 && (
+          <>
+            <SectionLabel>🏆 PLAYOFFS · {playoffSummary(state)}</SectionLabel>
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 22 }}>
+              {playoffSpecs.map((spec) => (
+                <MatchCardRow
+                  key={spec.id}
+                  tag={spec.label.toUpperCase()}
+                  left={describeSlot(spec.slot1, labelById)}
+                  right={describeSlot(spec.slot2, labelById)}
+                  isFinal={spec.isFinal}
+                  muted
+                />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Footer */}
+        <div
+          style={{
+            marginTop: 44,
+            paddingTop: 26,
+            borderTop: `1px solid ${CARD_BORDER}`,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            color: MUTED,
+            fontSize: 26,
+            fontWeight: 600,
+          }}
+        >
+          <span>🎯 {state.maxOvers} overs · {state.maxWickets} wkts</span>
+          <span>🏏 Cricket Planner</span>
+        </div>
+      </div>
+    );
+  },
+);
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        fontSize: 24,
+        fontWeight: 700,
+        letterSpacing: 3,
+        color: MUTED,
+        marginTop: 46,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** A single fixture rendered as an exciting VS card. */
+function MatchCardRow({
+  tag,
+  left,
+  right,
+  isFinal,
+  muted,
+}: {
+  tag: string;
+  left: string;
+  right: string;
+  isFinal?: boolean;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        background: isFinal
+          ? `linear-gradient(100deg, rgba(${ACCENT_SOFT},0.16), rgba(${ACCENT_SOFT},0.05))`
+          : CARD,
+        border: `1px solid ${isFinal ? `rgba(${ACCENT_SOFT},0.45)` : CARD_BORDER}`,
+        borderRadius: 22,
+        padding: "22px 30px 26px",
+      }}
+    >
+      {/* Eyebrow tag */}
+      <div
+        style={{
+          textAlign: "center",
+          fontSize: 20,
+          fontWeight: 700,
+          letterSpacing: 3,
+          color: isFinal ? ACCENT : MUTED,
+          marginBottom: 14,
+        }}
+      >
+        {isFinal ? `👑 ${tag}` : tag}
+      </div>
+
+      {/* Team A · VS · Team B */}
+      <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+        <div
+          style={{
+            flex: 1,
+            textAlign: "right",
+            fontSize: 36,
+            fontWeight: 700,
+            color: muted ? MUTED : TEXT,
+          }}
+        >
+          {left}
+        </div>
+        <div
+          style={{
+            flexShrink: 0,
+            width: 74,
+            height: 74,
+            borderRadius: "50%",
+            background: ACCENT,
+            color: INK,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            fontSize: 26,
+            fontWeight: 800,
+            letterSpacing: 1,
+          }}
+        >
+          VS
+        </div>
+        <div
+          style={{
+            flex: 1,
+            textAlign: "left",
+            fontSize: 36,
+            fontWeight: 700,
+            color: muted ? MUTED : TEXT,
+          }}
+        >
+          {right}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/tournaments/matches-view.tsx
+++ b/src/components/tournaments/matches-view.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import { Text, VStack, Box, HStack, Skeleton } from "@chakra-ui/react";
+import { LuShare2 } from "react-icons/lu";
 import { useLiveTournament } from "@/contexts/tournament-context/live-provider";
 import { MatchCard } from "@/components/tournaments/match-card";
 import { SampleResultsButton } from "@/components/tournaments/sample-results-button";
 import { FinishBanner } from "@/components/tournaments/finish-banner";
+import { ShareFixtureDialog } from "@/components/tournaments/share-fixture-dialog";
 import { Button } from "@/components/ui/button";
 
 /**
@@ -13,7 +16,8 @@ import { Button } from "@/components/ui/button";
  * scoring action reflects instantly without a server round-trip.
  */
 export function MatchesView() {
-  const { state, readOnly, hydrating } = useLiveTournament();
+  const { state, readOnly, hydrating, store } = useLiveTournament();
+  const [shareOpen, setShareOpen] = useState(false);
 
   // On a hard reload the server can't read localStorage; show a skeleton until
   // the client reveals the real state (instead of flashing stale DB data).
@@ -56,6 +60,22 @@ export function MatchesView() {
   return (
     <VStack align="stretch" gap={6}>
       <FinishBanner />
+
+      <Button
+        variant="outline"
+        colorPalette="green"
+        size="md"
+        w="full"
+        onClick={() => setShareOpen(true)}
+      >
+        <LuShare2 /> Share fixtures
+      </Button>
+
+      <ShareFixtureDialog
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        name={store.name}
+      />
 
       {process.env.NODE_ENV === "development" && !readOnly && pending > 0 && (
         <SampleResultsButton pending={pending} />

--- a/src/components/tournaments/share-fixture-dialog.tsx
+++ b/src/components/tournaments/share-fixture-dialog.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  CloseButton,
+  Dialog,
+  Input,
+  Portal,
+  Spinner,
+  Text,
+  VStack,
+} from "@chakra-ui/react";
+import { toPng } from "html-to-image";
+import { LuDownload, LuShare2 } from "react-icons/lu";
+import { Button } from "@/components/ui/button";
+import { toaster } from "@/components/ui/toaster";
+import { useLiveTournament } from "@/contexts/tournament-context/live-provider";
+import { FixtureCard, FIXTURE_CARD_WIDTH } from "@/components/tournaments/fixture-card";
+
+/**
+ * Share the pre-match fixture draft as an image. Lets the user set the match
+ * window, previews the generated card, and shares it via the native share sheet
+ * (WhatsApp etc.) with a download fallback. Fully on-device — no server needed.
+ */
+
+/** ISO (UTC) → the `YYYY-MM-DDTHH:mm` a datetime-local input expects (local time). */
+function isoToLocalInput(iso?: string): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
+    d.getHours(),
+  )}:${pad(d.getMinutes())}`;
+}
+
+/** datetime-local value (local time) → ISO string, or undefined when empty. */
+function localInputToIso(value: string): string | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
+}
+
+function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "tournament"
+  );
+}
+
+export function ShareFixtureDialog({
+  open,
+  onClose,
+  name,
+}: {
+  open: boolean;
+  onClose: () => void;
+  name: string;
+}) {
+  const { state, store } = useLiveTournament();
+  const cardRef = useRef<HTMLDivElement>(null);
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [rendering, setRendering] = useState(false);
+
+  const render = useCallback(async () => {
+    const node = cardRef.current;
+    if (!node) return;
+    setRendering(true);
+    try {
+      // Two frames so the off-screen card is laid out & painted before capture.
+      await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      const url = await toPng(node, {
+        width: FIXTURE_CARD_WIDTH,
+        pixelRatio: 1.5,
+        cacheBust: true,
+      });
+      setDataUrl(url);
+    } catch {
+      toaster.create({
+        title: "Couldn't build the image",
+        description: "Please try again.",
+        type: "error",
+        duration: 3500,
+      });
+    } finally {
+      setRendering(false);
+    }
+  }, []);
+
+  // (Re)generate whenever the dialog is open and the schedule/teams/matches change.
+  useEffect(() => {
+    if (!open) return;
+    void render();
+  }, [open, render, state.scheduledStart, state.scheduledEnd, state.teams, state.matches]);
+
+  const filename = `${slugify(name)}-fixtures.png`;
+
+  const handleDownload = () => {
+    if (!dataUrl) return;
+    const a = document.createElement("a");
+    a.href = dataUrl;
+    a.download = filename;
+    a.click();
+  };
+
+  const handleShare = async () => {
+    if (!dataUrl) return;
+    try {
+      const blob = await (await fetch(dataUrl)).blob();
+      const file = new File([blob], filename, { type: "image/png" });
+      const nav = navigator as Navigator & {
+        canShare?: (data?: ShareData) => boolean;
+      };
+      if (nav.canShare?.({ files: [file] }) && nav.share) {
+        await nav.share({
+          files: [file],
+          title: name,
+          text: `${name} — fixtures 🏏`,
+        });
+        return;
+      }
+      // No file-share support (e.g. desktop): fall back to a download.
+      handleDownload();
+      toaster.create({
+        title: "Image downloaded",
+        description: "Sharing isn't supported here — attach the saved image.",
+        type: "info",
+        duration: 3500,
+      });
+    } catch (err) {
+      // A user cancelling the share sheet throws AbortError — ignore it.
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      toaster.create({
+        title: "Couldn't share",
+        description: "Try downloading the image instead.",
+        type: "error",
+        duration: 3500,
+      });
+    }
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(e) => !e.open && onClose()}
+      scrollBehavior="inside"
+    >
+      <Portal>
+        <Dialog.Backdrop bg="dialog.backdrop" backdropFilter="blur(4px)" />
+        <Dialog.Positioner>
+          <Dialog.Content maxW="480px" mx={4} bg="dialog.bg" borderRadius="xl">
+            <Dialog.Header pb={2}>
+              <Dialog.Title fontSize="lg" fontWeight="600">
+                Share fixtures
+              </Dialog.Title>
+              <Dialog.CloseTrigger asChild>
+                <CloseButton
+                  position="absolute"
+                  top={4}
+                  right={4}
+                  size="sm"
+                  color="fg.muted"
+                  _hover={{ color: "fg.default", bg: "bg.subtle" }}
+                />
+              </Dialog.CloseTrigger>
+            </Dialog.Header>
+
+            <Dialog.Body pb={5}>
+              <VStack align="stretch" gap={5}>
+                {/* Match window editor */}
+                <VStack align="stretch" gap={3}>
+                  <Text fontSize="sm" fontWeight="600" color="fg.default">
+                    🗓️ Match window
+                  </Text>
+                  <VStack align="stretch" gap={2.5}>
+                    <Box>
+                      <Text fontSize="xs" color="fg.muted" mb={1}>
+                        Starts
+                      </Text>
+                      <Input
+                        type="datetime-local"
+                        size="md"
+                        value={isoToLocalInput(state.scheduledStart)}
+                        onChange={(e) =>
+                          store.setSchedule(
+                            localInputToIso(e.target.value),
+                            state.scheduledEnd,
+                          )
+                        }
+                      />
+                    </Box>
+                    <Box>
+                      <Text fontSize="xs" color="fg.muted" mb={1}>
+                        Ends
+                      </Text>
+                      <Input
+                        type="datetime-local"
+                        size="md"
+                        value={isoToLocalInput(state.scheduledEnd)}
+                        onChange={(e) =>
+                          store.setSchedule(
+                            state.scheduledStart,
+                            localInputToIso(e.target.value),
+                          )
+                        }
+                      />
+                    </Box>
+                  </VStack>
+                  <Text fontSize="xs" color="fg.muted">
+                    Saved on this device — Sync from the top bar to store it.
+                  </Text>
+                </VStack>
+
+                {/* Preview */}
+                <Box
+                  position="relative"
+                  bg="bg.subtle"
+                  borderRadius="lg"
+                  borderWidth={1}
+                  borderColor="border.subtle"
+                  overflow="hidden"
+                  minH="140px"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  {dataUrl ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={dataUrl}
+                      alt="Fixture card preview"
+                      style={{ width: "100%", display: "block" }}
+                    />
+                  ) : (
+                    <Spinner size="md" color="fg.muted" />
+                  )}
+                  {rendering && dataUrl && (
+                    <Box
+                      position="absolute"
+                      top={2}
+                      right={2}
+                      bg="bg.canvas"
+                      borderRadius="full"
+                      p={1.5}
+                    >
+                      <Spinner size="xs" color="fg.muted" />
+                    </Box>
+                  )}
+                </Box>
+
+                {/* Actions */}
+                <VStack align="stretch" gap={2.5}>
+                  <Button
+                    colorPalette="green"
+                    size="lg"
+                    onClick={handleShare}
+                    disabled={!dataUrl || rendering}
+                  >
+                    <LuShare2 /> Share to WhatsApp
+                  </Button>
+                  <Button
+                    variant="outline"
+                    colorPalette="gray"
+                    size="lg"
+                    onClick={handleDownload}
+                    disabled={!dataUrl || rendering}
+                  >
+                    <LuDownload /> Download image
+                  </Button>
+                </VStack>
+              </VStack>
+            </Dialog.Body>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+
+      {/* Off-screen full-size render target for the PNG capture. */}
+      <Box
+        position="fixed"
+        top={0}
+        left="-99999px"
+        pointerEvents="none"
+        aria-hidden
+      >
+        <FixtureCard ref={cardRef} tournamentName={name} state={state} />
+      </Box>
+    </Dialog.Root>
+  );
+}

--- a/src/components/tournaments/wizard/creation-wizard.tsx
+++ b/src/components/tournaments/wizard/creation-wizard.tsx
@@ -162,7 +162,12 @@ export function CreationWizard() {
         maxWickets,
       });
       // Generate the schedule locally into this id's store, then open matches.
-      const store = new TournamentStore({ id, status: "setup", state: initialState });
+      const store = new TournamentStore({
+        id,
+        name: name.trim(),
+        status: "setup",
+        state: initialState,
+      });
       const res = store.generate({
         teams,
         maxOvers,

--- a/src/contexts/tournament-context/engine.ts
+++ b/src/contexts/tournament-context/engine.ts
@@ -123,6 +123,24 @@ export function setPlayoffConfig(
   return { ...state, playoffConfig: config };
 }
 
+/**
+ * Set (or clear) the planned "match night" window. Pass ISO strings, or
+ * undefined for either bound to leave it unset. Returns the same reference when
+ * nothing changes so `useSyncExternalStore` consumers don't re-render.
+ */
+export function setSchedule(
+  state: TournamentState,
+  start: string | undefined,
+  end: string | undefined,
+): TournamentState {
+  const nextStart = start || undefined;
+  const nextEnd = end || undefined;
+  if (state.scheduledStart === nextStart && state.scheduledEnd === nextEnd) {
+    return state;
+  }
+  return { ...state, scheduledStart: nextStart, scheduledEnd: nextEnd };
+}
+
 // ── Match generation ─────────────────────────────────────────────────────────
 
 export function generateMatches(state: TournamentState): {

--- a/src/contexts/tournament-context/types.ts
+++ b/src/contexts/tournament-context/types.ts
@@ -131,6 +131,10 @@ export interface TournamentState {
   // The resolved playoff structure used to generate playoff matches.
   // null before generation and for the "none" format.
   playoffConfig: PlayoffConfig | null;
+  // Optional planned "match night" window (ISO 8601 strings). Used for display
+  // and the shareable fixture card; absent for tournaments with no set schedule.
+  scheduledStart?: string;
+  scheduledEnd?: string;
 }
 
 // Extended types for future features

--- a/src/lib/local/__tests__/tournament-store.test.ts
+++ b/src/lib/local/__tests__/tournament-store.test.ts
@@ -54,7 +54,12 @@ function scheduledMatchState(): TournamentState {
 }
 
 const inProgress = (id: string) =>
-  new TournamentStore({ id, status: "in_progress", state: scheduledMatchState() });
+  new TournamentStore({
+    id,
+    name: "Test Cup",
+    status: "in_progress",
+    state: scheduledMatchState(),
+  });
 
 describe("TournamentStore — hydration", () => {
   it("serves the DB state when no local copy exists, and does not write on construction", () => {
@@ -128,6 +133,7 @@ describe("TournamentStore — hydration", () => {
   it("never hydrates a completed tournament (renders straight from the DB)", () => {
     const store = new TournamentStore({
       id: "HY2",
+      name: "Test Cup",
       status: "completed",
       state: scheduledMatchState(),
     });
@@ -155,6 +161,7 @@ describe("TournamentStore — mutations persist locally", () => {
   it("generate() builds the schedule locally and persists", () => {
     const store = new TournamentStore({
       id: "GEN",
+      name: "Test Cup",
       status: "setup",
       state: initialState,
     });
@@ -213,6 +220,7 @@ describe("TournamentStore — completed is a pure read (INVARIANT 2)", () => {
   it("serves DB state read-only and never touches localStorage", () => {
     const store = new TournamentStore({
       id: "DONE",
+      name: "Test Cup",
       status: "completed",
       state: scheduledMatchState(),
     });
@@ -239,6 +247,7 @@ describe("TournamentStore — cross-tournament isolation (INVARIANT 1)", () => {
     // Open (and even poke at) completed tournament B.
     const b = new TournamentStore({
       id: "B",
+      name: "Test Cup",
       status: "completed",
       state: scheduledMatchState(),
     });

--- a/src/lib/local/tournament-store.ts
+++ b/src/lib/local/tournament-store.ts
@@ -30,6 +30,7 @@ export type TournamentStatus = "setup" | "in_progress" | "completed";
 /** Everything the store needs from the server to bootstrap. */
 export interface StoreInit {
   id: string;
+  name: string;
   status: TournamentStatus;
   state: TournamentState;
 }
@@ -88,6 +89,8 @@ function canUseStorage(): boolean {
 
 export class TournamentStore {
   readonly id: string;
+  /** Tournament display name (static metadata, not part of the reactive state). */
+  readonly name: string;
 
   /** In-memory cache — a stable reference between mutations. */
   private snapshot: LocalSnapshot;
@@ -99,6 +102,7 @@ export class TournamentStore {
 
   constructor(init: StoreInit) {
     this.id = init.id;
+    this.name = init.name;
     const readOnly = init.status === "completed";
 
     // Server + hydration snapshot: the DB state. For an in-progress tournament
@@ -226,6 +230,11 @@ export class TournamentStore {
     const gen = engine.generateMatches(next);
     if (gen.success) this.commit(gen.state);
     return { success: gen.success, errors: gen.errors };
+  }
+
+  /** Set (or clear) the planned match-night window. ISO strings, or undefined. */
+  setSchedule(start: string | undefined, end: string | undefined): void {
+    this.commit(engine.setSchedule(this.snapshot.state, start, end));
   }
 
   /** Dev-only: fill scheduled non-TBD matches with random in-progress scores. */

--- a/src/lib/repositories/tournament-repository.ts
+++ b/src/lib/repositories/tournament-repository.ts
@@ -69,6 +69,8 @@ const numOrUndef = (v: unknown): number | undefined =>
   v === null || v === undefined ? undefined : Number(v);
 const strOrUndef = (v: unknown): string | undefined =>
   v === null || v === undefined ? undefined : String(v);
+const isoOrUndef = (v: unknown): string | undefined =>
+  v === null || v === undefined ? undefined : new Date(v as string).toISOString();
 
 /** High-level lifecycle derived from the tournament state. */
 function deriveStatus(state: TournamentState): TournamentStatus {
@@ -277,6 +279,8 @@ async function loadRecord(db: Db, t: Row): Promise<TournamentRecord> {
     phase: t.phase as TournamentPhase,
     playoffFormat,
     playoffConfig,
+    scheduledStart: isoOrUndef(t.scheduled_start),
+    scheduledEnd: isoOrUndef(t.scheduled_end),
   };
 
   return {
@@ -351,8 +355,8 @@ async function writeState(
     `update public.tournaments
         set algorithm = $1, playoff_format = $2, playoff_config = $3,
             max_overs = $4, max_wickets = $5, is_generated = $6, phase = $7,
-            status = $8, winner = $9
-      where id = $10 and user_id = $11
+            status = $8, winner = $9, scheduled_start = $10, scheduled_end = $11
+      where id = $12 and user_id = $13
       returning updated_at`,
     [
       state.algorithm,
@@ -364,6 +368,8 @@ async function writeState(
       state.phase,
       deriveStatus(state),
       getTournamentWinner(state),
+      state.scheduledStart ?? null,
+      state.scheduledEnd ?? null,
       id,
       userId,
     ],

--- a/supabase/migrations/0003_tournament_schedule.sql
+++ b/supabase/migrations/0003_tournament_schedule.sql
@@ -1,0 +1,16 @@
+-- Tournament schedule window.
+--
+-- Adds an optional planned start/end for a tournament ("match night" window,
+-- e.g. Fri 11pm → Sat 2am) so it can be shown in the app and printed onto the
+-- shareable fixture card. Both nullable: existing tournaments have no schedule
+-- and stay valid.
+
+begin;
+
+alter table public.tournaments
+  add column if not exists scheduled_start timestamptz;
+
+alter table public.tournaments
+  add column if not exists scheduled_end timestamptz;
+
+commit;


### PR DESCRIPTION
Add a "Share fixtures" flow that renders the tournament draft (match window, group-stage fixtures, and playoff bracket) to an on-device PNG for posting to WhatsApp etc. via the native share sheet, with a download fallback. Fully local-first — no server round-trip.

- Persist an optional match-night window (scheduledStart/scheduledEnd) on TournamentState, wired through the engine, local store, and repository; migration 0003 adds the nullable timestamptz columns.
- Carry the tournament name on the local store so client views can label the shared card.
- FixtureCard: fixed 1080px, theme-independent render target using the app's blue scale; vs-style match cards, a minimal date/time + duration line, and playoff slots described in plain language ("1st on points table", "Winner · Qualifier 1") with the final highlighted.
- ShareFixtureDialog: set the window, preview the generated image, and share/download via html-to-image.