### PR TITLE
feat(sharing): shareable tournament stats card

### DIFF
--- a/src/components/tournaments/fixture-card.tsx
+++ b/src/components/tournaments/fixture-card.tsx
@@ -5,6 +5,18 @@ import type {
   TournamentState,
   PlayoffSlot,
 } from "@/contexts/tournament-context/types";
+import {
+  ACCENT,
+  ACCENT_SOFT,
+  CARD,
+  CARD_BG,
+  CARD_BORDER,
+  CARD_WIDTH,
+  FONT,
+  INK,
+  MUTED,
+  TEXT,
+} from "@/components/tournaments/share/card-style";
 
 /**
  * The shareable fixture-draft card. Rendered at a fixed 1080px design width and
@@ -16,19 +28,7 @@ import type {
  * pixel width is correct — the output is an image, not a responsive screen.
  */
 
-// Fixed design palette (theme-independent) — the app's blue scale (theme.ts).
-const INK = "#0c142e"; // blue.950 — deep ground
-const INK_2 = "#1a365d"; // blue.900
-const CARD = "rgba(255,255,255,0.05)";
-const CARD_BORDER = "rgba(255,255,255,0.12)";
-const ACCENT = "#63b3ed"; // blue.300 — bright accent on dark
-const ACCENT_SOFT = "99,179,237"; // blue.300 as rgb, for translucent fills
-const TEXT = "#eaf2fb";
-const MUTED = "#9db6d4";
-const FONT =
-  '"Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
-
-export const FIXTURE_CARD_WIDTH = 1080;
+export const FIXTURE_CARD_WIDTH = CARD_WIDTH;
 
 export interface FixtureCardProps {
   tournamentName: string;
@@ -118,7 +118,7 @@ export const FixtureCard = forwardRef<HTMLDivElement, FixtureCardProps>(
           boxSizing: "border-box",
           fontFamily: FONT,
           color: TEXT,
-          background: `radial-gradient(120% 80% at 50% -10%, ${INK_2} 0%, ${INK} 60%)`,
+          background: CARD_BG,
           padding: "72px 64px 60px",
         }}
       >

--- a/src/components/tournaments/share-stats-dialog.tsx
+++ b/src/components/tournaments/share-stats-dialog.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   CloseButton,
   Dialog,
-  Input,
   Portal,
   Spinner,
   Text,
@@ -15,7 +14,7 @@ import { LuDownload, LuShare2 } from "react-icons/lu";
 import { Button } from "@/components/ui/button";
 import { toaster } from "@/components/ui/toaster";
 import { useLiveTournament } from "@/contexts/tournament-context/live-provider";
-import { FixtureCard } from "@/components/tournaments/fixture-card";
+import { StatsCard } from "@/components/tournaments/stats-card";
 import {
   downloadDataUrl,
   nextPaint,
@@ -25,30 +24,11 @@ import {
 } from "@/components/tournaments/share/capture";
 
 /**
- * Share the pre-match fixture draft as an image. Lets the user set the match
- * window, previews the generated card, and shares it via the native share sheet
+ * Share the tournament stats (points table, awards, highlights) as an image.
+ * Previews the generated card and shares it via the native share sheet
  * (WhatsApp etc.) with a download fallback. Fully on-device — no server needed.
  */
-
-/** ISO (UTC) → the `YYYY-MM-DDTHH:mm` a datetime-local input expects (local time). */
-function isoToLocalInput(iso?: string): string {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours(),
-  )}:${pad(d.getMinutes())}`;
-}
-
-/** datetime-local value (local time) → ISO string, or undefined when empty. */
-function localInputToIso(value: string): string | undefined {
-  if (!value) return undefined;
-  const d = new Date(value);
-  return Number.isNaN(d.getTime()) ? undefined : d.toISOString();
-}
-
-export function ShareFixtureDialog({
+export function ShareStatsDialog({
   open,
   onClose,
   name,
@@ -57,7 +37,7 @@ export function ShareFixtureDialog({
   onClose: () => void;
   name: string;
 }) {
-  const { state, store } = useLiveTournament();
+  const { state } = useLiveTournament();
   const cardRef = useRef<HTMLDivElement>(null);
   const [dataUrl, setDataUrl] = useState<string | null>(null);
   const [rendering, setRendering] = useState(false);
@@ -81,13 +61,13 @@ export function ShareFixtureDialog({
     }
   }, []);
 
-  // (Re)generate whenever the dialog is open and the schedule/teams/matches change.
+  // (Re)generate whenever the dialog is open and the underlying data changes.
   useEffect(() => {
     if (!open) return;
     void render();
-  }, [open, render, state.scheduledStart, state.scheduledEnd, state.teams, state.matches]);
+  }, [open, render, state.matches, state.teamStats]);
 
-  const filename = `${slugify(name)}-fixtures.png`;
+  const filename = `${slugify(name)}-stats.png`;
 
   const handleDownload = () => {
     if (dataUrl) downloadDataUrl(dataUrl, filename);
@@ -98,7 +78,7 @@ export function ShareFixtureDialog({
     try {
       const { shared } = await shareOrDownloadImage(dataUrl, filename, {
         title: name,
-        text: `${name} — fixtures 🏏`,
+        text: `${name} — stats 🏏`,
       });
       if (!shared) {
         toaster.create({
@@ -109,7 +89,6 @@ export function ShareFixtureDialog({
         });
       }
     } catch (err) {
-      // A user cancelling the share sheet throws AbortError — ignore it.
       if (err instanceof DOMException && err.name === "AbortError") return;
       toaster.create({
         title: "Couldn't share",
@@ -132,7 +111,7 @@ export function ShareFixtureDialog({
           <Dialog.Content maxW="480px" mx={4} bg="dialog.bg" borderRadius="xl">
             <Dialog.Header pb={2}>
               <Dialog.Title fontSize="lg" fontWeight="600">
-                Share fixtures
+                Share stats
               </Dialog.Title>
               <Dialog.CloseTrigger asChild>
                 <CloseButton
@@ -148,49 +127,10 @@ export function ShareFixtureDialog({
 
             <Dialog.Body pb={5}>
               <VStack align="stretch" gap={5}>
-                {/* Match window editor */}
-                <VStack align="stretch" gap={3}>
-                  <Text fontSize="sm" fontWeight="600" color="fg.default">
-                    🗓️ Match window
-                  </Text>
-                  <VStack align="stretch" gap={2.5}>
-                    <Box>
-                      <Text fontSize="xs" color="fg.muted" mb={1}>
-                        Starts
-                      </Text>
-                      <Input
-                        type="datetime-local"
-                        size="md"
-                        value={isoToLocalInput(state.scheduledStart)}
-                        onChange={(e) =>
-                          store.setSchedule(
-                            localInputToIso(e.target.value),
-                            state.scheduledEnd,
-                          )
-                        }
-                      />
-                    </Box>
-                    <Box>
-                      <Text fontSize="xs" color="fg.muted" mb={1}>
-                        Ends
-                      </Text>
-                      <Input
-                        type="datetime-local"
-                        size="md"
-                        value={isoToLocalInput(state.scheduledEnd)}
-                        onChange={(e) =>
-                          store.setSchedule(
-                            state.scheduledStart,
-                            localInputToIso(e.target.value),
-                          )
-                        }
-                      />
-                    </Box>
-                  </VStack>
-                  <Text fontSize="xs" color="fg.muted">
-                    Saved on this device — Sync from the top bar to store it.
-                  </Text>
-                </VStack>
+                <Text fontSize="sm" color="fg.muted">
+                  Points table, team awards, and match highlights — ready for the
+                  group chat.
+                </Text>
 
                 {/* Preview */}
                 <Box
@@ -209,7 +149,7 @@ export function ShareFixtureDialog({
                     // eslint-disable-next-line @next/next/no-img-element
                     <img
                       src={dataUrl}
-                      alt="Fixture card preview"
+                      alt="Tournament stats preview"
                       style={{ width: "100%", display: "block" }}
                     />
                   ) : (
@@ -232,7 +172,7 @@ export function ShareFixtureDialog({
                 {/* Actions */}
                 <VStack align="stretch" gap={2.5}>
                   <Button
-                    colorPalette="green"
+                    colorPalette="blue"
                     size="lg"
                     onClick={handleShare}
                     disabled={!dataUrl || rendering}
@@ -256,14 +196,8 @@ export function ShareFixtureDialog({
       </Portal>
 
       {/* Off-screen full-size render target for the PNG capture. */}
-      <Box
-        position="fixed"
-        top={0}
-        left="-99999px"
-        pointerEvents="none"
-        aria-hidden
-      >
-        <FixtureCard ref={cardRef} tournamentName={name} state={state} />
+      <Box position="fixed" top={0} left="-99999px" pointerEvents="none" aria-hidden>
+        <StatsCard ref={cardRef} tournamentName={name} state={state} />
       </Box>
     </Dialog.Root>
   );

--- a/src/components/tournaments/share/capture.ts
+++ b/src/components/tournaments/share/capture.ts
@@ -1,0 +1,66 @@
+// Shared capture + share helpers for the image cards.
+//
+// Kept framework-free (plain functions) so both share dialogs reuse the exact
+// same PNG generation and native-share behavior. All rendering happens
+// on-device — no server round-trip.
+
+import { toPng } from "html-to-image";
+import { CARD_WIDTH } from "./card-style";
+
+/** Filesystem-safe slug for a tournament name (used in the download filename). */
+export function slugify(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "tournament"
+  );
+}
+
+/** Render a laid-out card node to a PNG data URL at the fixed design width. */
+export function nodeToPng(node: HTMLElement): Promise<string> {
+  return toPng(node, {
+    width: CARD_WIDTH,
+    pixelRatio: 1.5,
+    cacheBust: true,
+  });
+}
+
+/** Wait two frames so an off-screen card is laid out & painted before capture. */
+export function nextPaint(): Promise<void> {
+  return new Promise((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+  );
+}
+
+/** Trigger a browser download of a data URL. */
+export function downloadDataUrl(dataUrl: string, filename: string): void {
+  const a = document.createElement("a");
+  a.href = dataUrl;
+  a.download = filename;
+  a.click();
+}
+
+/**
+ * Share a PNG via the native share sheet, falling back to a download when the
+ * platform can't share files (e.g. desktop browsers). Returns whether the
+ * native share sheet was used. Re-throws so callers can special-case the user
+ * cancelling the sheet (AbortError).
+ */
+export async function shareOrDownloadImage(
+  dataUrl: string,
+  filename: string,
+  meta: { title: string; text: string },
+): Promise<{ shared: boolean }> {
+  const blob = await (await fetch(dataUrl)).blob();
+  const file = new File([blob], filename, { type: "image/png" });
+  const nav = navigator as Navigator & {
+    canShare?: (data?: ShareData) => boolean;
+  };
+  if (nav.canShare?.({ files: [file] }) && nav.share) {
+    await nav.share({ files: [file], title: meta.title, text: meta.text });
+    return { shared: true };
+  }
+  downloadDataUrl(dataUrl, filename);
+  return { shared: false };
+}

--- a/src/components/tournaments/share/card-style.ts
+++ b/src/components/tournaments/share/card-style.ts
@@ -1,0 +1,26 @@
+// Shared visual identity for the shareable image cards (fixture, stats).
+//
+// These are captured to PNGs and posted to WhatsApp etc., so they are styled
+// with explicit hex colors — NOT Chakra theme tokens — to look identical for
+// every viewer and to never follow the app's light/dark mode. The palette is
+// the app's blue scale (see components/theme.ts), with a gold accent reserved
+// for the champion, mirroring the in-app champion styling.
+
+export const CARD_WIDTH = 1080;
+
+export const INK = "#0c142e"; // blue.950 — deep ground
+export const INK_2 = "#1a365d"; // blue.900
+export const CARD = "rgba(255,255,255,0.05)";
+export const CARD_BORDER = "rgba(255,255,255,0.12)";
+export const ACCENT = "#63b3ed"; // blue.300 — bright accent on dark
+export const ACCENT_SOFT = "99,179,237"; // blue.300 as rgb, for translucent fills
+export const GOLD = "#f6c453"; // champion accent
+export const GOLD_SOFT = "246,196,83";
+export const TEXT = "#eaf2fb";
+export const MUTED = "#9db6d4";
+
+export const FONT =
+  '"Segoe UI", system-ui, -apple-system, "Helvetica Neue", Arial, sans-serif';
+
+/** The card ground — a subtle radial from blue.900 to blue.950. */
+export const CARD_BG = `radial-gradient(120% 80% at 50% -10%, ${INK_2} 0%, ${INK} 60%)`;

--- a/src/components/tournaments/stats-card.tsx
+++ b/src/components/tournaments/stats-card.tsx
@@ -1,0 +1,367 @@
+"use client";
+
+import { forwardRef } from "react";
+import type { TournamentState } from "@/contexts/tournament-context/types";
+import {
+  computeTournamentInsights,
+  type Award,
+  type Highlight,
+} from "@/contexts/tournament-context/algorithms/insights";
+import {
+  getTournamentStandings,
+  formatNRR,
+} from "@/contexts/tournament-context/algorithms/cricket-stats";
+import {
+  ACCENT,
+  ACCENT_SOFT,
+  CARD,
+  CARD_BG,
+  CARD_BORDER,
+  FONT,
+  GOLD,
+  GOLD_SOFT,
+  MUTED,
+  TEXT,
+} from "@/components/tournaments/share/card-style";
+
+/**
+ * The shareable tournament-stats card: champion/leader, the points table, team
+ * awards, and match highlights. Rendered at a fixed 1080px width and captured
+ * to a PNG for sharing. Theme-independent by design (see card-style.ts) —
+ * mirrors the app's blue identity with gold reserved for the champion.
+ */
+
+export interface StatsCardProps {
+  tournamentName: string;
+  state: TournamentState;
+}
+
+export const StatsCard = forwardRef<HTMLDivElement, StatsCardProps>(
+  function StatsCard({ tournamentName, state }, ref) {
+    const insights = computeTournamentInsights(state);
+    const standings = getTournamentStandings(state.teamStats).filter(
+      (t) => t.matchesPlayed > 0,
+    );
+
+    return (
+      <div
+        ref={ref}
+        style={{
+          width: 1080,
+          boxSizing: "border-box",
+          fontFamily: FONT,
+          color: TEXT,
+          background: CARD_BG,
+          padding: "72px 64px 60px",
+        }}
+      >
+        {/* Eyebrow */}
+        <div style={{ fontSize: 24, fontWeight: 700, letterSpacing: 4, color: ACCENT }}>
+          🏏 TOURNAMENT STATS
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: 78,
+            fontWeight: 800,
+            lineHeight: 1.04,
+            marginTop: 16,
+            letterSpacing: -1,
+          }}
+        >
+          {tournamentName}
+        </div>
+
+        {/* At-a-glance totals */}
+        <div style={{ marginTop: 22, display: "flex", gap: 40, flexWrap: "wrap" }}>
+          <Stat value={insights.matchesCompleted} label="matches played" />
+          <Stat value={insights.totalRuns} label="runs scored" />
+          <Stat value={insights.totalWickets} label="wickets taken" />
+        </div>
+
+        {/* Champion / leader hero */}
+        {insights.champion ? (
+          <Hero
+            emoji="🏆"
+            eyebrow="CHAMPIONS"
+            name={insights.champion}
+            note="Tournament winner"
+            gold
+          />
+        ) : (
+          insights.standout && (
+            <Hero
+              emoji="🌟"
+              eyebrow="TEAM TO BEAT"
+              name={insights.standout.team}
+              note={`Leading ${insights.standout.awardCount} of ${insights.standout.totalAwards} awards`}
+            />
+          )
+        )}
+
+        {/* Points table */}
+        {standings.length > 0 && (
+          <>
+            <SectionLabel>📋 POINTS TABLE</SectionLabel>
+            <div style={{ marginTop: 20 }}>
+              <TableHeader />
+              {standings.map((t, i) => {
+                const champ = t.teamName === insights.champion;
+                return (
+                  <TableRow
+                    key={t.teamName}
+                    pos={i + 1}
+                    team={t.teamName}
+                    p={t.matchesPlayed}
+                    w={t.wins}
+                    l={t.losses}
+                    pts={t.points}
+                    nrr={formatNRR(t.netRunRate)}
+                    highlight={champ}
+                  />
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {/* Team awards */}
+        {insights.awards.length > 0 && (
+          <>
+            <SectionLabel>⭐ TEAM AWARDS</SectionLabel>
+            <div
+              style={{
+                marginTop: 20,
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 16,
+              }}
+            >
+              {insights.awards.map((a) => (
+                <AwardTile key={a.key} award={a} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Match highlights */}
+        {insights.highlights.length > 0 && (
+          <>
+            <SectionLabel>🎬 MATCH HIGHLIGHTS</SectionLabel>
+            <div style={{ marginTop: 20, display: "flex", flexDirection: "column", gap: 14 }}>
+              {insights.highlights.map((h) => (
+                <HighlightRow key={h.key} highlight={h} />
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Footer */}
+        <div
+          style={{
+            marginTop: 46,
+            paddingTop: 26,
+            borderTop: `1px solid ${CARD_BORDER}`,
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+            color: MUTED,
+            fontSize: 26,
+            fontWeight: 600,
+          }}
+        >
+          <span>🎯 {state.maxOvers} overs</span>
+          <span>🏏 Cricket Planner</span>
+        </div>
+      </div>
+    );
+  },
+);
+
+// ── Primitives ────────────────────────────────────────────────────────────────
+
+function Stat({ value, label }: { value: number; label: string }) {
+  return (
+    <div>
+      <div style={{ fontSize: 52, fontWeight: 800, color: ACCENT, lineHeight: 1 }}>
+        {value.toLocaleString()}
+      </div>
+      <div style={{ fontSize: 24, color: MUTED, fontWeight: 600, marginTop: 4 }}>
+        {label}
+      </div>
+    </div>
+  );
+}
+
+function Hero({
+  emoji,
+  eyebrow,
+  name,
+  note,
+  gold,
+}: {
+  emoji: string;
+  eyebrow: string;
+  name: string;
+  note: string;
+  gold?: boolean;
+}) {
+  const soft = gold ? GOLD_SOFT : ACCENT_SOFT;
+  const ring = gold ? GOLD : ACCENT;
+  return (
+    <div
+      style={{
+        marginTop: 34,
+        background: `linear-gradient(100deg, rgba(${soft},0.2), rgba(${soft},0.06))`,
+        border: `1px solid rgba(${soft},0.5)`,
+        borderRadius: 26,
+        padding: "34px 30px",
+        textAlign: "center",
+      }}
+    >
+      <div style={{ fontSize: 60, lineHeight: 1 }}>{emoji}</div>
+      <div style={{ fontSize: 22, fontWeight: 700, letterSpacing: 4, color: ring, marginTop: 10 }}>
+        {eyebrow}
+      </div>
+      <div style={{ fontSize: 60, fontWeight: 800, marginTop: 6 }}>{name}</div>
+      <div style={{ fontSize: 26, color: MUTED, fontWeight: 600, marginTop: 8 }}>{note}</div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div style={{ fontSize: 24, fontWeight: 700, letterSpacing: 3, color: MUTED, marginTop: 48 }}>
+      {children}
+    </div>
+  );
+}
+
+// Points-table column layout, shared by header and rows.
+const COLS = "56px 1fr 90px 90px 90px 110px 130px";
+
+function TableHeader() {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: COLS,
+        alignItems: "center",
+        padding: "0 24px 12px",
+        fontSize: 22,
+        fontWeight: 700,
+        letterSpacing: 1,
+        color: MUTED,
+      }}
+    >
+      <span>#</span>
+      <span>TEAM</span>
+      <span style={{ textAlign: "center" }}>P</span>
+      <span style={{ textAlign: "center" }}>W</span>
+      <span style={{ textAlign: "center" }}>L</span>
+      <span style={{ textAlign: "center" }}>PTS</span>
+      <span style={{ textAlign: "center" }}>NRR</span>
+    </div>
+  );
+}
+
+function TableRow({
+  pos,
+  team,
+  p,
+  w,
+  l,
+  pts,
+  nrr,
+  highlight,
+}: {
+  pos: number;
+  team: string;
+  p: number;
+  w: number;
+  l: number;
+  pts: number;
+  nrr: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: COLS,
+        alignItems: "center",
+        padding: "20px 24px",
+        marginBottom: 10,
+        borderRadius: 16,
+        background: highlight
+          ? `linear-gradient(100deg, rgba(${GOLD_SOFT},0.16), rgba(${GOLD_SOFT},0.05))`
+          : CARD,
+        border: `1px solid ${highlight ? `rgba(${GOLD_SOFT},0.45)` : CARD_BORDER}`,
+        fontSize: 30,
+      }}
+    >
+      <span style={{ fontWeight: 800, color: highlight ? GOLD : ACCENT }}>{pos}</span>
+      <span style={{ fontWeight: 700, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+        {highlight ? `👑 ${team}` : team}
+      </span>
+      <Num>{p}</Num>
+      <Num>{w}</Num>
+      <Num>{l}</Num>
+      <span style={{ textAlign: "center", fontWeight: 800 }}>{pts}</span>
+      <span style={{ textAlign: "center", fontWeight: 700, color: MUTED }}>{nrr}</span>
+    </div>
+  );
+}
+
+function Num({ children }: { children: React.ReactNode }) {
+  return <span style={{ textAlign: "center", fontWeight: 600, color: MUTED }}>{children}</span>;
+}
+
+function AwardTile({ award }: { award: Award }) {
+  return (
+    <div
+      style={{
+        background: CARD,
+        border: `1px solid ${CARD_BORDER}`,
+        borderRadius: 20,
+        padding: "24px 26px",
+      }}
+    >
+      <div style={{ fontSize: 22, color: MUTED, fontWeight: 600 }}>
+        {award.emoji} {award.title}
+      </div>
+      <div style={{ fontSize: 38, fontWeight: 800, marginTop: 8 }}>{award.team}</div>
+      <div style={{ fontSize: 24, fontWeight: 600, color: ACCENT, marginTop: 4 }}>
+        {award.metric}
+      </div>
+    </div>
+  );
+}
+
+function HighlightRow({ highlight: h }: { highlight: Highlight }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 22,
+        background: CARD,
+        border: `1px solid ${CARD_BORDER}`,
+        borderRadius: 18,
+        padding: "20px 28px",
+      }}
+    >
+      <span style={{ fontSize: 44, flexShrink: 0 }}>{h.emoji}</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 22, color: MUTED, fontWeight: 600 }}>{h.title}</div>
+        <div style={{ fontSize: 34, fontWeight: 700, marginTop: 2 }}>{h.headline}</div>
+      </div>
+      {h.detail && (
+        <span style={{ fontSize: 24, color: ACCENT, fontWeight: 600, flexShrink: 0 }}>
+          {h.detail}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/components/tournaments/stats-view.tsx
+++ b/src/components/tournaments/stats-view.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Badge,
   Box,
@@ -9,7 +10,10 @@ import {
   Text,
   VStack,
 } from "@chakra-ui/react";
+import { LuShare2 } from "react-icons/lu";
+import { Button } from "@/components/ui/button";
 import { useLiveTournament } from "@/contexts/tournament-context/live-provider";
+import { ShareStatsDialog } from "@/components/tournaments/share-stats-dialog";
 import {
   computeTournamentInsights,
   type Award,
@@ -19,7 +23,8 @@ import {
 
 /** Fun, energetic tournament analytics — the big numbers, highlights, and awards. */
 export function StatsView() {
-  const { state, hydrating } = useLiveTournament();
+  const { state, hydrating, store } = useLiveTournament();
+  const [shareOpen, setShareOpen] = useState(false);
   if (hydrating) return null;
 
   const insights = computeTournamentInsights(state);
@@ -43,6 +48,22 @@ export function StatsView() {
 
   return (
     <VStack align="stretch" gap={7}>
+      <Button
+        variant="outline"
+        colorPalette="blue"
+        size="md"
+        w="full"
+        onClick={() => setShareOpen(true)}
+      >
+        <LuShare2 /> Share stats
+      </Button>
+
+      <ShareStatsDialog
+        open={shareOpen}
+        onClose={() => setShareOpen(false)}
+        name={store.name}
+      />
+
       {insights.champion ? (
         <ChampionHero champion={insights.champion} />
       ) : (


### PR DESCRIPTION
Add a "Share stats" flow on the Stats tab that renders the tournament wrap-up — at-a-glance totals, champion/leader, points table, team awards, and match highlights — to an on-device PNG for the group chat, reusing the existing insights the Stats page already computes.

- StatsCard: fixed 1080px render target in the shared blue identity, with gold reserved for the champion (crowned points-table topper).
- ShareStatsDialog: preview the generated image and share/download it.
- Extract the shared card palette (share/card-style.ts) and the PNG capture + native-share logic (share/capture.ts); the fixture card and dialog now build on the same helpers — one source of truth for the look and the share behavior.